### PR TITLE
illustrate spring boot application properties

### DIFF
--- a/src/main/java/guru/springframework/sfgdi/config/GreetingServiceConfig.java
+++ b/src/main/java/guru/springframework/sfgdi/config/GreetingServiceConfig.java
@@ -9,7 +9,6 @@ import guru.springframework.sfgdi.services.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.*;
 
-@PropertySource("classpath:datasource.properties")
 @ImportResource("classpath:sfgdi-config.xml")
 @Configuration
 public class GreetingServiceConfig {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 spring.application.name=sfg-di
 #spring.profiles.active=cat,ES
+guru.username=user
+guru.password=pass
+guru.jdbcUrl=someUrl

--- a/src/main/resources/datasource.properties
+++ b/src/main/resources/datasource.properties
@@ -1,3 +1,0 @@
-guru.username=user
-guru.password=pass
-guru.jdbcUrl=someUrl


### PR DESCRIPTION
This is to illustrate that with spring boot, properties can be supplied directly in application.properties and there is no need of `@PropertySource` to read properties from that file, as this is taken care of by spring boot.